### PR TITLE
calculate init_code_hash into a fixed value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 
-export network=https://solo.veblocks.net
+export network=http://solo.veblocks.net
 export chaintag=0xa4
 export private=dce1443bd2ef0c2631adc1c67e5c93f13dc23a41c18b536effbbdcbcdb96fb65 # address: 0x7567d83b7b8d80addcb281a71d54fc7b3364ffed
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Some contracts are deployed on testnet:
 
 | Contract       | Address                                    |
 | -------------- | ------------------------------------------ |
-| vVET           | 0xcFc6be8bB30FBAc8cECF8f943810eE0C561b4F7a |
+| vVET           | 0x37a3e90ff4a6eb312097367e0210d7d7d9699fdd |
 | vtho           | 0x0000000000000000000000000000456e65726779 |
-| factory        | 0xfa00742a63f20B4a867cfd0758bf3bd39B5ce6af |
-| router02       | 0x084b404b3A75e22Aa015b88eb160D22D3a81e719 |
-| vVET/VTHO pool | 0x306adfec67692dc0a3c4a6b2282be1d4877d98ca |
+| factory        | 0xa876ea32b4540780a51fdf795a28ba1930231aa9 |
+| router02       | 0x2ea79c98350d7d2bec2225f1bb7587d3fd355fa0 |
+| vVET/VTHO pool | 0xc6ff007b5e42c270089f120f485e184e52c50f4b |

--- a/calc_hash.py
+++ b/calc_hash.py
@@ -1,0 +1,13 @@
+import json
+from thor_devkit import cry
+
+def read_json_file(path_like: str) -> dict:
+    ''' Read json file '''
+    with open(path_like, 'r') as f:
+        return json.load(f)
+
+if __name__ == "__main__":
+    b = read_json_file('./core/build/contracts/UniswapV2Pair.json')
+    h = bytes.fromhex(b['bytecode'])
+    digest, _ = cry.keccak256([h])
+    print('UniswapV2Pair init_code_hash:', digest.hex())

--- a/core/contracts/UniswapV2ERC20.sol
+++ b/core/contracts/UniswapV2ERC20.sol
@@ -22,9 +22,12 @@ contract UniswapV2ERC20 is IUniswapV2ERC20 {
     event Transfer(address indexed from, address indexed to, uint value);
 
     constructor() public {
-        // TODO: OPCODE chainid not supported on VeChain yet. We fix this to 1.
+        // TODO: OPCODE chainid not supported on VeChain yet.
+        // mainnet: 0x4a
+        // testnet: 0x27
+        // solo: 0xa4
         // But really needs to be fixed before launch!
-        uint chainId = 1;
+        uint chainId = 0x27;
         // assembly {
         //     chainId := chainid
         // }

--- a/deploy.py
+++ b/deploy.py
@@ -158,7 +158,7 @@ def _find_created_contracts(receipt: dict) -> list:
     return a
 
 
-def wait_for_receipt(network: str, tx_id: str, wait_for: int = 10) -> dict:
+def wait_for_receipt(network: str, tx_id: str, wait_for: int = 20) -> dict:
     ''' Wait for wait_for seconds (default 10s) to find the receipt on-chain '''
     interval = 3
     rounds = wait_for // interval

--- a/periphery/contracts/libraries/UniswapV2Library.sol
+++ b/periphery/contracts/libraries/UniswapV2Library.sol
@@ -19,13 +19,14 @@ library UniswapV2Library {
     function pairFor(address factory, address tokenA, address tokenB) internal view returns (address pair) {
         (address token0, address token1) = sortTokens(tokenA, tokenB);
         // TODO: hash maybe incorrect for generating CREATE2 address for pair. (due to bytecode change)
-        // pair = address(uint(keccak256(abi.encodePacked(
-        //         hex'ff',
-        //         factory,
-        //         keccak256(abi.encodePacked(token0, token1)),
-        //         hex'96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f' // init code hash
-        //     ))));
-        pair = IUniswapV2Factory(factory).getPair(token0, token1);
+        pair = address(uint(keccak256(abi.encodePacked(
+                hex'ff',
+                factory,
+                keccak256(abi.encodePacked(token0, token1)),
+                hex'562f2d7da4edf65b4ccd515d0735f351468cd0b5af54e7395c6890f88247e6d5' // init code hash
+            ))));
+        // TODO: for a temp solution (waste more gas)
+        // pair = IUniswapV2Factory(factory).getPair(token0, token1);
     }
 
     // fetches and sorts the reserves for a pair


### PR DESCRIPTION
Hi,

This commit fixes the "waste gas" style of calling getPair() on the library, and we now have a fixed init_code_hash.

To recalculate if you have changed the smart contract content, call "python3 calc_hash.py" again.